### PR TITLE
Version 2.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Pi-hole® v5 changed the way blocked queries are logged. Download the latest [Pi
 
 Info | Description
 ------|----------
-Version | 2.1.7 - See on [Splunkbase](https://splunkbase.splunk.com/app/4506/)
+Version | 2.1.8 - See on [Splunkbase](https://splunkbase.splunk.com/app/4506/)
 Vendor Product Version | [Pi-hole® v5.2.x, FTL 5.7](https://pi-hole.net/)
 App has a web UI | Yes. This App contains views.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Vendor Product Version | [Pi-hole® v5.2.x, FTL 5.7](https://pi-hole.net/)
 App has a web UI | Yes. This App contains views.
 
 ```TEXT
+Version 2.1.8
+
+Fix
+- Removed spaces from `pihole_summariesonly` search macro causing dashboards to have the error "Error in 'tstats' command: Option '=' is invalid." - #31
+
+------
+
 Version 2.1.7
 
 New

--- a/app.manifest
+++ b/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "pihole_dns_app",
-      "version": "2.1.7"
+      "version": "2.1.8"
     },
     "author": [
       {

--- a/default/app.conf
+++ b/default/app.conf
@@ -2,7 +2,7 @@
 # Splunk app configuration file
 #
 [install]
-build = 4
+build = 5
 
 [ui]
 is_visible = 1
@@ -11,7 +11,7 @@ label = Pi-hole DNS App for Splunk
 [launcher]
 author = Zach Christensen
 description = Dashboards for the Pi-hole DNS Server.
-version = 2.1.7
+version = 2.1.8
 
 [package]
 id = pihole_dns_app

--- a/default/macros.conf
+++ b/default/macros.conf
@@ -34,5 +34,5 @@ definition = lookup pihole_blocklist_lookup domain as "$domain_field$" OUTPUTNEW
 iseval     = 0
 
 [pihole_summariesonly]
-definition = summariesonly = false
+definition = summariesonly=false
 iseval     = 0


### PR DESCRIPTION
Fixes "Error in 'tstats' command: Option '=' is invalid." introduced in version 2.1.6 - #31 